### PR TITLE
Find gadget leaf

### DIFF
--- a/include/Gadget.h
+++ b/include/Gadget.h
@@ -151,7 +151,8 @@ namespace rose {
         }
 
         bool containsPoint(const Point &point) {
-            return (mVisualMetrics.borderRect + mVisualMetrics.lastDrawLocation).contains(point);
+            auto r = (mVisualMetrics.borderRect + mVisualMetrics.lastDrawLocation).contains(point);
+            return r;
         }
 
         /**

--- a/include/Gadget.h
+++ b/include/Gadget.h
@@ -64,6 +64,14 @@ namespace rose {
             Point drawLocation{};
 
             /**
+             * @brief The las position provided to Gadget::Draw.
+             * @details This position, along with the remainder of the VisualMetrics, is used to provide aspects
+             * of functionality. If a Gadget does not call the base class draw function it should set this value
+             * correctly itself to maintain this functionality.
+             */
+            Point lastDrawLocation{};
+
+            /**
              * @brief The content drawing size requested by the Gadget.
              */
             Size desiredSize{};
@@ -140,6 +148,10 @@ namespace rose {
             bool a = manager.owner_before(wt{});
             bool b = wt{}.owner_before(manager);
             return !(!a && !b);
+        }
+
+        bool containsPoint(const Point &point) {
+            return (mVisualMetrics.borderRect + mVisualMetrics.lastDrawLocation).contains(point);
         }
 
         /**

--- a/include/Rose.h
+++ b/include/Rose.h
@@ -209,8 +209,11 @@ namespace rose {
 
         explicit operator bool () const { return point.set && size.set; }
 
+        // ToDo: fix all related comparison operators. <=> not really doing what we want.
         [[maybe_unused]] bool contains(const Point &p) {
-            return p >= point && p < (point + size);
+            auto p2 = point + size;
+            auto r = point.x <= p.x && point.y <= p.y && p.x < p2.x && p.y < p2.y;
+            return r;
         }
 
         [[nodiscard]] Rectangle intersection(const Rectangle &o) const {

--- a/include/Window.h
+++ b/include/Window.h
@@ -130,14 +130,25 @@ namespace rose {
         [[maybe_unused]] void setFocusGadget(std::shared_ptr<Gadget> &gadget);
 
         /**
-         * @brief Preorder traversal of a Widget tree applying a lambda to all Gadgets.
+         * @brief Preorder traversal of a Widget tree to apply a lambda to each Gadget.
          * @details The tree is traversed starting from the specified Gadget. Gadgets which are also Widgets are
-         * traversed in turn. The provided lambda is applied to all Gadgets. Traversal preorder.
+         * traversed in turn. The provided lambda is applied to all Gadgets. Traversal is preorder.
          * @param topGadget The Gadget to start traversal from.
          * @param lambda The lambda to apply.
          */
         static void gadgetTraversal(std::shared_ptr<Screen> &topGadget,
                                     const std::function< void(std::shared_ptr<Gadget>&) >& lambda);
+
+        /**
+         * @brief Preorder traversal of a Widget tree to find a leaf Gadget.
+         * @details The tree is traversed starting from the specified Gadget. Gadgets which are also Widgets are
+         * traversed in turn. The provided lambda is applied to all Gadgets. Only Gadgets for which the lambda
+         * returns true are searched.
+         * @param topGadget The Gadget to start traversal from.
+         * @param lambda The lambda to apply.
+         */
+        static std::shared_ptr<Gadget> gadgetFindLast(std::shared_ptr<Screen> &topGadget,
+                                     const std::function< bool(std::shared_ptr<Gadget>&) >& lambda);
 
         /**
          * @brief Clear all focus flags for Gadgets attached to this Window using gadgetTraversal.

--- a/include/Window.h
+++ b/include/Window.h
@@ -140,7 +140,7 @@ namespace rose {
                                     const std::function< void(std::shared_ptr<Gadget>&) >& lambda);
 
         /**
-         * @brief Preorder traversal of a Widget tree to find a leaf Gadget.
+         * @brief Post-order traversal of a Widget tree to find a leaf Gadget.
          * @details The tree is traversed starting from the specified Gadget. Gadgets which are also Widgets are
          * traversed in turn. The provided lambda is applied to all Gadgets. Only Gadgets for which the lambda
          * returns true are searched.

--- a/include/Window.h
+++ b/include/Window.h
@@ -48,6 +48,30 @@ namespace rose {
             mVisualMetrics.background = color::TransparentBlack;
         }
 
+        /**
+         * @brief Perform initial Gadget layout.
+         * @details The Gadget has an opportunity to specify its own desiredSize by overriding this method.
+         * @param drawLocation
+         * @param mgrPadding
+         */
+        bool initialGadgetLayout(Context &context) override {
+            forceInitialGadgetLayout();
+            return Widget::initialGadgetLayout(context);
+        }
+
+        /**
+         * @brief Draw this Widget and all managed Gadgets.
+         * @param context The graphics context to use.
+         */
+//        void draw(Context &context, Point drawLocation) override {
+//            Gadget::draw(context, drawLocation);
+//
+//            for (const auto& gadget : mGadgetList) {
+//                Point gadgetDrawLocation = drawLocation + gadget->getVisualMetrics().drawLocation;
+//                gadget->draw(context, gadgetDrawLocation);
+//            }
+//        }
+
         ~Screen() override = default;
     };
 
@@ -84,6 +108,8 @@ namespace rose {
         Context& context() { return mContext; }
 
         SdlWindow& sdlWindow() { return mSdlWindow; }
+
+        std::shared_ptr<Gadget> findGadget(const std::function< bool(std::shared_ptr<Gadget>&) >& lambda);
 
         auto windowID() { return SDL_GetWindowID(mSdlWindow.get()); }
 

--- a/src/Gadget.cpp
+++ b/src/Gadget.cpp
@@ -22,6 +22,7 @@ namespace rose {
         colorGuard.setDrawColor(RenderRectangleDebugColor);
         context.fillRect(mVisualMetrics.renderRect + drawLocation);
 #else
+        mVisualMetrics.lastDrawLocation = drawLocation;
         if (mVisualMetrics.background) {
             DrawColorGuard colorGuard{context, mVisualMetrics.background};
             context.fillRect(mVisualMetrics.borderRect + drawLocation);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -79,6 +79,29 @@ namespace rose {
         }
     }
 
+    std::shared_ptr<Gadget> Window::gadgetFindLast(std::shared_ptr<Screen> &topGadget,
+                                                   const std::function<bool(std::shared_ptr<Gadget> &)> &lambda) {
+
+        std::stack<std::shared_ptr<Gadget>> stack{};
+        stack.push(topGadget);
+        std::shared_ptr<Gadget> result;
+
+        while (!stack.empty()) {
+            auto gadget = stack.top();
+            stack.pop();
+            if (lambda(gadget)) {
+                result = gadget;
+                if (auto widget = std::dynamic_pointer_cast<Widget>(gadget); widget) {
+                    std::ranges::reverse_view reverseGadgetList{widget->mGadgetList};
+                    for (auto &newGadget : reverseGadgetList) {
+                        stack.push(newGadget);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
     void
     Window::initialize(const std::shared_ptr<Application>& applicationPtr, const std::string &title, Size initialSize,
                        const Point &initialPosition, uint32_t extraFlags) {

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -79,6 +79,16 @@ namespace rose {
         }
     }
 
+    std::shared_ptr<Gadget> Window::findGadget(const std::function<bool(std::shared_ptr<Gadget> &)> &lambda) {
+        std::ranges::reverse_view reverseScreenView{mScreens};
+        std::shared_ptr<Gadget> gadget{};
+        for (auto topLevel : reverseScreenView) {
+            if (gadget = gadgetFindLast(topLevel, lambda); gadget)
+                return gadget;
+        }
+        return gadget;
+    }
+
     std::shared_ptr<Gadget> Window::gadgetFindLast(std::shared_ptr<Screen> &topGadget,
                                                    const std::function<bool(std::shared_ptr<Gadget> &)> &lambda) {
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -92,8 +92,8 @@ namespace rose {
             if (lambda(gadget)) {
                 result = gadget;
                 if (auto widget = std::dynamic_pointer_cast<Widget>(gadget); widget) {
-                    std::ranges::reverse_view reverseGadgetList{widget->mGadgetList};
-                    for (auto &newGadget : reverseGadgetList) {
+//                    std::ranges::reverse_view reverseGadgetList{widget->mGadgetList};
+                    for (auto &newGadget : widget->mGadgetList) {
                         stack.push(newGadget);
                     }
                 }


### PR DESCRIPTION
Added ability to find a leaf (nor near-leaf) gadget for which the path from root to found gadget meets a given criteria. Combined this with mouse motion event processing to derive Enter/Leave events for Gadgets.